### PR TITLE
Added 'city' to tags (it was missing)

### DIFF
--- a/json/advert-schema_v1.0.0.json
+++ b/json/advert-schema_v1.0.0.json
@@ -1334,6 +1334,7 @@
                 ],
                 "enum": [
                   "chalet",
+                  "city",
                   "coastal",
                   "cottage",
                   "detached",


### PR DESCRIPTION
The 'tags' section should have 'city' after 'chalet' but it's missing from the schema