### PR TITLE
Syndicated adverts changes (new fields in advert section)

### DIFF
--- a/json/internal/advert-schema_v1.0.0.json
+++ b/json/internal/advert-schema_v1.0.0.json
@@ -50,6 +50,18 @@
         "string"
       ]
     },
+    "agency_logo": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "syndicator_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "agency_branch_name": {
       "type": [
         "null",
@@ -306,6 +318,18 @@
         null,
         "all_images_deleted",
         "image_4+_deleted"
+      ]
+    },
+    "syndicator_tag": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "syndicator_name": {
+      "type": [
+        "null",
+        "string"
       ]
     }
   },

--- a/json/internal/advert-schema_v1.0.0.json
+++ b/json/internal/advert-schema_v1.0.0.json
@@ -56,12 +56,6 @@
         "string"
       ]
     },
-    "syndicator_name": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "agency_branch_name": {
       "type": [
         "null",

--- a/json/internal/advert-schema_v1.0.0.json
+++ b/json/internal/advert-schema_v1.0.0.json
@@ -122,6 +122,12 @@
         "string"
       ]
     },
+    "external_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "type": {
       "type": [
         "string"


### PR DESCRIPTION
https://app.shortcut.com/frenchproperty/story/11899/add-new-fields-to-advert-json-schema

Add the following nullable string fields:

```
advert.agency_logo
advert.external_id
advert.syndicator_tag
advert.syndicator_name
```